### PR TITLE
Dimensions: Don't trust non-pixel computed width/height

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -153,9 +153,13 @@ function getWidthOrHeight( elem, dimension, extra ) {
 		isBorderBox = jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
 		valueIsBorderBox = isBorderBox;
 
-	// Computed unit is not pixels. Stop here and return.
+	// Support: Firefox <=54
+	// Return a confounding non-pixel value or feign ignorance, as appropriate.
 	if ( rnumnonpx.test( val ) ) {
-		return val;
+		if ( !extra ) {
+			return val;
+		}
+		val = "auto";
 	}
 
 	// Check for style in case a browser which returns unreliable values

--- a/test/unit/dimensions.js
+++ b/test/unit/dimensions.js
@@ -544,6 +544,29 @@ QUnit.test( "width/height on an inline element with no explicitly-set dimensions
 	} );
 } );
 
+QUnit.test( "width/height on an inline element with percentage dimensions (gh-3611)",
+	function( assert ) {
+		assert.expect( 4 );
+
+		jQuery( "<div id='gh3611' style='width: 100px;'>" +
+			"<span style='width: 100%; padding: 0 5px'>text</span>" +
+		"</div>" ).appendTo( "#qunit-fixture" );
+
+		var $elem = jQuery( "#gh3611 span" ),
+			actualWidth = $elem[ 0 ].getBoundingClientRect().width,
+			marginWidth = $elem.outerWidth( true ),
+			borderWidth = $elem.outerWidth(),
+			paddingWidth = $elem.innerWidth(),
+			contentWidth = $elem.width();
+
+		assert.equal( Math.round( borderWidth ), Math.round( actualWidth ),
+			".outerWidth(): " + borderWidth + " approximates " + actualWidth );
+		assert.equal( marginWidth, borderWidth, ".outerWidth(true) matches .outerWidth()" );
+		assert.equal( paddingWidth, borderWidth, ".innerWidth() matches .outerWidth()" );
+		assert.equal( contentWidth, borderWidth - 10, ".width() excludes padding" );
+	}
+);
+
 QUnit.test( "width/height on a table row with phantom borders (gh-3698)", function( assert ) {
 	assert.expect( 4 );
 


### PR DESCRIPTION
Fixes gh-3611
Closes gh-3741

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
