### PR TITLE
Update upstream

### DIFF
--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -300,7 +300,7 @@ testIframe(
 		expected = expectedMap.firefox_60;
 	} else if ( /firefox/i.test( userAgent ) ) {
 		expected = expectedMap.firefox;
-	} else if ( /iphone os 11_/i.test( userAgent ) ) {
+	} else if ( /(?:iphone|ipad);.*(?:iphone)? os 11_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_11;
 	} else if ( /iphone os (?:9|10)_/i.test( userAgent ) ) {
 		expected = expectedMap.ios_9_10;


### PR DESCRIPTION
The user agent of the iPad with iOS 11.3 on BrowserStack is missing the "iPhone"
part in the "iPhone OS 11_3" part. This commit makes the iOS regex accept such
(probably?) malformed UAs.

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
