### PR TITLE
Update documentation for

### DIFF
--- a/src/css.js
+++ b/src/css.js
@@ -358,10 +358,14 @@ jQuery.each( [ "height", "width" ], function( i, dimension ) {
 		set: function( elem, value, extra ) {
 			var matches,
 				styles = getStyles( elem ),
-				scrollBoxSize = support.scrollboxSize() === styles.position,
+
+				// Only read styles.position if the test has a chance to fail
+				// to avoid forcing a reflow.
+				scrollboxSizeBuggy = !support.scrollboxSize() &&
+					styles.position === "absolute",
 
 				// To avoid forcing a reflow, only fetch boxSizing if we need it (gh-3991)
-				boxSizingNeeded = scrollBoxSize || extra,
+				boxSizingNeeded = scrollboxSizeBuggy || extra,
 				isBorderBox = boxSizingNeeded &&
 					jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
 				subtract = extra ?
@@ -376,7 +380,7 @@ jQuery.each( [ "height", "width" ], function( i, dimension ) {
 
 			// Account for unreliable border-box dimensions by comparing offset* to computed and
 			// faking a content-box to get border and padding (gh-3699)
-			if ( isBorderBox && scrollBoxSize ) {
+			if ( isBorderBox && scrollboxSizeBuggy ) {
 				subtract -= Math.ceil(
 					elem[ "offset" + dimension[ 0 ].toUpperCase() + dimension.slice( 1 ) ] -
 					parseFloat( styles[ dimension ] ) -

--- a/src/css/support.js
+++ b/src/css/support.js
@@ -46,7 +46,7 @@ define( [
 		// Support: Chrome <=64
 		// Don't get tricked when zoom affects offsetWidth (gh-4029)
 		div.style.position = "absolute";
-		scrollboxSizeVal = roundPixelMeasures( div.offsetWidth / 3 ) === 12 || "absolute";
+		scrollboxSizeVal = roundPixelMeasures( div.offsetWidth / 3 ) === 12;
 
 		documentElement.removeChild( container );
 

--- a/test/unit/support.js
+++ b/test/unit/support.js
@@ -107,7 +107,7 @@ testIframe(
 				"pixelPosition": true,
 				"radioValue": false,
 				"reliableMarginLeft": true,
-				"scrollboxSize": "absolute"
+				"scrollboxSize": false
 			},
 			chrome: {
 				"ajax": true,


### PR DESCRIPTION
…cessary

Current width/height cssHook reads the computed position style even if not
necessary as the browser passes the scrollboxSize support test. That has been
changed.

This commit also makes the scrollboxSize support test in line with all others
(i.e. only return true or false) and changes the variable name in the hook
to make the code clearer.

Fixes gh-4185
Closes gh-4187

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
