### PR TITLE
Support multiple versions of 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -11,7 +11,7 @@ Bug Reports:
   *  Which browsers are affected?
   Provide a *minimal* test case, see https://webkit.org/test-case-reduction/
   Use the latest shipping version of jQuery in your test case!
-  We prefer test cases on https://jsbin.com or https://jsfiddle.net
+  We prefer test cases on JS Bin (https://jsbin.com/qawicop/edit?html,css,js,output) or CodePen (https://codepen.io/mgol/pen/wNWJbZ)
 
 Frequently Reported Issues:
   * Selectors with '#' break: See https://github.com/jquery/jquery/issues/2824


### PR DESCRIPTION
JSFiddle doesn't support IE (even 11) anymore so we shouldn't advise users
to use it to create test cases. To make people have a choice, add CodePen
to the list.

Also, link to specific starter templates so that novices don't need to spend
time thinking how to set up the basic structure.

Closes gh-4289

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
