### PR TITLE
Make full-icu the default

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -91,6 +91,8 @@ Scott González <scott.gonzalez@gmail.com> <sgonzale@sgonzale-laptop.local>
 Scott Jehl <scottjehl@gmail.com> <scott@scottjehl.com>
 Sebastian Burkhard <sebi.burkhard@gmail.com>
 Senya Pugach <upisfree@outlook.com>
+Shashanka Nataraj <shashankan.10@gmail.com>
+Shashanka Nataraj <shashankan.10@gmail.com> <ShashankaNataraj@users.noreply.github.com>
 Thomas Tortorini <thomastortorini@gmail.com> Mr21
 Timmy Willison <4timmywil@gmail.com>
 Timmy Willison <4timmywil@gmail.com> <timmywillisn@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -352,3 +352,5 @@ Hoang <dangkyokhoang@gmail.com>
 Wonseop Kim <wonseop.kim@samsung.com>
 Pat O'Callaghan <patocallaghan@gmail.com>
 JuanMa Ruiz <ruizjuanma@gmail.com>
+Ahmed.S.ElAfifi <ahmed.s.elafifi@gmail.com>
+Sean Robinson <sean.robinson@scottsdalecc.edu>


### PR DESCRIPTION
After recent merging of Sizzle & jQuery AUTHORS.txt, the `grunt authors` task
doesn't provide meaningful as there's no obvious connection between current
AUTHORS.txt contents & the desired one. Adding two new entries should make it
easier (plus, it makes it possible to test jquery-release on current master).

Apart from that, the commit adds a missing .mailmap entry for Shashanka Nataraj.

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
