### PR TITLE
Fix rustdoc display with js disabled

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -3,13 +3,16 @@ var fs = require( "fs" );
 module.exports = function( Release ) {
 
 	var
-		files = [
+		distFiles = [
 			"dist/jquery.js",
 			"dist/jquery.min.js",
 			"dist/jquery.min.map",
 			"dist/jquery.slim.js",
 			"dist/jquery.slim.min.js",
-			"dist/jquery.slim.min.map",
+			"dist/jquery.slim.min.map"
+		],
+		filesToCommit = [
+			...distFiles,
 			"src/core.js"
 		],
 		cdn = require( "./release/cdn" ),
@@ -46,7 +49,7 @@ module.exports = function( Release ) {
 			);
 			cdn.makeReleaseCopies( Release );
 			Release._setSrcVersion();
-			callback( files );
+			callback( filesToCommit );
 		},
 
 		/**
@@ -67,7 +70,7 @@ module.exports = function( Release ) {
 		 */
 		dist: function( callback ) {
 			cdn.makeArchives( Release, function() {
-				dist( Release, files, callback );
+				dist( Release, distFiles, callback );
 			} );
 		}
 	} );


### PR DESCRIPTION
File `src/core.js` has started erroneously being copied to `dist/` in gh-2981.

Fixes gh-4489
Closes gh-4492
Ref gh-2979
Ref gh-2981

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
