### PR TITLE
Log the error return from store

### DIFF
--- a/build/release/dist.js
+++ b/build/release/dist.js
@@ -130,7 +130,8 @@ module.exports = function( Release, files, complete ) {
 		Release.chdir( Release.dir.dist );
 
 		console.log( "Pushing release to dist repo..." );
-		Release.exec( "git push " + distRemote + " master --tags",
+		Release.exec( "git push " + ( Release.isTest ? " --dry-run " : "" ) +
+			distRemote + " master --tags",
 			"Error pushing master and tags to git repo." );
 
 		// Set repo for npm publish


### PR DESCRIPTION
Without this change passing `--dry-run` to jquery-release still pushes to the
jquery-dist repository which is dangerous as one can assume `--dry-run` to be
safe from external side effects.

Close gh-4498

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
