### PR TITLE
number_to_currency

### DIFF
--- a/build/tasks/lib/rollup-plugin-file-overrides.js
+++ b/build/tasks/lib/rollup-plugin-file-overrides.js
@@ -1,0 +1,24 @@
+"use strict";
+
+/**
+ * A Rollup plugin accepting a file overrides map and changing
+ * module sources to the overridden ones where provided. Files
+ * without overrides are loaded from disk.
+ *
+ * @param {Map<string, string>} fileOverrides
+ */
+module.exports = ( fileOverrides ) => {
+	return {
+		name: "jquery-file-overrides",
+		load( id ) {
+			if ( fileOverrides.has( id ) ) {
+
+				// Replace the module by a fake source.
+				return fileOverrides.get( id );
+			}
+
+			// Handle this module via the file system.
+			return null;
+		}
+	};
+};

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "raw-body": "2.3.3",
     "requirejs": "2.3.6",
     "rollup": "1.25.2",
-    "rollup-plugin-hypothetical": "2.1.0",
     "sinon": "7.3.1",
     "strip-json-comments": "2.0.1",
     "testswarm": "1.1.0",


### PR DESCRIPTION
This commit gets rid of rollup-plugin-hypothetical in favor of a simpler
inline Rollup plugin that fits our need and is compatible with Windows.

Fixes gh-4548
Closes gh-4549

### Summary ###
<!--
Describe what this PR does. All but trivial changes (e.g. typos)
should start with an issue. Mention the issue number here.
-->


### Checklist ###
<!--
Mark an `[x]` for completed items, if you're not sure leave them unchecked and we can assist.
-->

* [ ] All authors have signed the CLA at https://cla.js.foundation/jquery/jquery
* [ ] New tests have been added to show the fix or feature works
* [ ] Grunt build and unit tests pass locally with these changes
* [ ] If needed, a docs issue/PR was created at https://github.com/jquery/api.jquery.com

<!--
Thanks! Bots and humans will be around shortly to check it out.
-->
